### PR TITLE
Adapt some style to please rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+Rubocop::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/anvil.gemspec
+++ b/anvil.gemspec
@@ -9,13 +9,15 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Fran Casas', 'Jon de Andres']
   spec.email         = %w(nflamel@otrobloggeek.com jondeandres@gmail.com)
   spec.description   = 'Anvil is a tool for building tools.'
-  spec.summary       = 'Anvil is a tool for building tools. A tool for a real craftsmen use to build its tools.'
+  spec.summary       = <<SUMMARY
+Anvil is a tool for building tools. A tool that a real craftsmen uses to build its tools.
+SUMMARY
   spec.homepage      = 'http://github.com/franciscoj/anvil'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = %w(lib)
 
   # Runtime dependencies
@@ -30,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',   '~> 2.14'
   spec.add_development_dependency 'byebug',  '~> 2.6'
   spec.add_development_dependency 'fakefs',  '~> 0.5'
+  spec.add_development_dependency 'rubocop', '~> 0.18.1'
 end

--- a/lib/anvil/assures/directory_assure.rb
+++ b/lib/anvil/assures/directory_assure.rb
@@ -1,6 +1,5 @@
 module Anvil
   class DirectoryAssure < Anvil::FileAssure
-
     def assured?(dir)
       super && assure_dir?(dir)
     end

--- a/lib/anvil/assures/file_assure.rb
+++ b/lib/anvil/assures/file_assure.rb
@@ -1,6 +1,5 @@
 module Anvil
   class FileAssure < Anvil::Assure
-
     def assured?(file)
       assure_exists? file
     end

--- a/lib/anvil/cli.rb
+++ b/lib/anvil/cli.rb
@@ -47,7 +47,7 @@ HELP
     end
 
     def print_help
-      printf("%s", HELP)
+      printf('%s', HELP)
       tasks = Anvil::TaskManager.tasks_by_name
       tasks.each { |task| print_task_line(task) }
     end

--- a/lib/anvil/task.rb
+++ b/lib/anvil/task.rb
@@ -41,7 +41,7 @@ module Anvil
     end
 
     def run_task
-      self.task
+      task
     end
   end
 end

--- a/spec/lib/assures/file_assure_spec.rb
+++ b/spec/lib/assures/file_assure_spec.rb
@@ -11,4 +11,3 @@ describe Anvil::FileAssure do
     it { should_not be_assured('dummy_file.txt') }
   end
 end
-

--- a/spec/lib/task/options_spec.rb
+++ b/spec/lib/task/options_spec.rb
@@ -21,7 +21,7 @@ describe Anvil::Task::Options do
       end
     end
 
-    let(:arguments) { ['arg1', 'arg2', '--install'] }
+    let(:arguments) { %w{arg1 arg2 --install} }
 
     let(:expected) do
       ['arg1', 'arg2', { install: true }]

--- a/spec/support/fixtures/dummy_assure.rb
+++ b/spec/support/fixtures/dummy_assure.rb
@@ -1,3 +1,5 @@
 class DummyAssure < Anvil::Assure
-  def assured?; true; end
+  def assured?
+    true
+  end
 end

--- a/spec/support/fixtures/dummy_failed_assure.rb
+++ b/spec/support/fixtures/dummy_failed_assure.rb
@@ -1,3 +1,5 @@
 class DummyFailedAssure < Anvil::Assure
-  def assured?; false; end
+  def assured?
+    false
+  end
 end

--- a/spec/support/fixtures/foo/dummy_task.rb
+++ b/spec/support/fixtures/foo/dummy_task.rb
@@ -3,4 +3,3 @@ module Foo
     def task; end
   end
 end
-


### PR DESCRIPTION
Actually I think that once we go open source and integrate with Travis we should include rubocop in the automated tests, probably including an agreed config file for it...
