### PR TITLE
Remove bundler dependency on runtime.

### DIFF
--- a/lib/anvil/task_manager.rb
+++ b/lib/anvil/task_manager.rb
@@ -1,7 +1,6 @@
 require 'anvil/config'
 require 'anvil/task'
 require 'rubygems'
-require 'bundler/shared_helpers'
 
 module Anvil
   module TaskManager
@@ -17,8 +16,12 @@ module Anvil
     end
 
     def self.files_from_current_project
-      path = File.dirname(Bundler::SharedHelpers.default_gemfile) + '/lib/anvil/'
+      path = current_project_path + '/lib/anvil/'
       files_from_path(path)
+    end
+
+    def self.current_project_path
+      %x{git rev-parse --show-toplevel}.strip
     end
 
     def self.files_from_path(path)

--- a/spec/lib/anvil/task_manager_spec.rb
+++ b/spec/lib/anvil/task_manager_spec.rb
@@ -10,7 +10,7 @@ describe Anvil::TaskManager do
   end
 
   describe '.files_from_current_project' do
-    let(:gemfile_path) { File.dirname(Bundler::SharedHelpers.default_gemfile) }
+    let(:gemfile_path) { described_class.current_project_path }
     let(:project_task_path) { gemfile_path + '/lib/anvil/' }
 
     it 'returns the task files in the path' do


### PR DESCRIPTION
We can now trust on `git rev-parse --show-toplevel` instead of have
bundler as dependency.

closed https://github.com/anvil-src/anvil-core/issues/11
