### PR TITLE
Adds a default message when anvil help is invoked with no more arguments

### DIFF
--- a/lib/tasks/help_task.rb
+++ b/lib/tasks/help_task.rb
@@ -14,7 +14,12 @@ class HelpTask < Anvil::Task
   end
 
   def task
+    return default_message unless task_name.present?
     klazz = Anvil::Task.from_name(task_name)
     printf(klazz.help)
+  end
+
+  def default_message
+    printf(self.class.help)
   end
 end


### PR DESCRIPTION
When invoking anvil help, it raises an error:

``` ruby
bundle exec bin/anvil help

/Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/inflector/methods.rb:238:in `const_get': wrong constant name {}Task (NameError)
    from /Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/inflector/methods.rb:238:in `block in constantize'
    from /Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/inflector/methods.rb:236:in `each'
    from /Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/inflector/methods.rb:236:in `inject'
    from /Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/inflector/methods.rb:236:in `constantize'
    from /Users/manu/anvil-core/vendor/bundle/gems/activesupport-4.1.1/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
    from /Users/manu/anvil-core/lib/anvil/task/naming.rb:20:in `from_name'
    from /Users/manu/anvil-core/lib/tasks/help_task.rb:18:in `task'
    from /Users/manu/anvil-core/lib/anvil/task.rb:56:in `run_task'
    from /Users/manu/anvil-core/lib/anvil/task.rb:26:in `run'
    from /Users/manu/anvil-core/lib/anvil/cli.rb:25:in `run'
    from bin/anvil:6:in `<main>'
```

With this fix, it shows a default messsage:

``` code
bundle exec bin/anvil help

Usage: anvil help TASK_NAME [options]

Help for the anvil tasks. Usage: anvil help TASK
```
