### PR TITLE
Fix rugged version and repo discovery

### DIFF
--- a/anvil-core.gemspec
+++ b/anvil-core.gemspec
@@ -28,7 +28,7 @@ SUMMARY
   spec.add_runtime_dependency 'mixlib-config', '~> 2.1'
   spec.add_runtime_dependency 'cocaine',   '~> 0.5'
   spec.add_runtime_dependency 'semantic',  '~> 1.3'
-  spec.add_runtime_dependency 'rugged',    '~> 0.19'
+  spec.add_runtime_dependency 'rugged',    '~> 0.21.0'
 
   # Development dependencies
   spec.add_development_dependency 'bundler', '~> 1.5'

--- a/lib/anvil/extensions_manager.rb
+++ b/lib/anvil/extensions_manager.rb
@@ -99,7 +99,7 @@ module Anvil
 
     # @return [String] top level dir if this is a git managed project
     def current_project_path
-      Rugged::Repository.discover(Dir.pwd).gsub('.git/', '')
+      Rugged::Repository.discover(Dir.pwd).path.gsub('.git/', '')
     rescue Rugged::RepositoryError
       ''
     end

--- a/spec/lib/anvil/extensions_manager_spec.rb
+++ b/spec/lib/anvil/extensions_manager_spec.rb
@@ -26,7 +26,7 @@ describe Anvil::ExtensionsManager do
     context 'on a path managed by git' do
       before do
         Rugged::Repository.stub(:discover)
-          .and_return(pwd + '.git/')
+          .and_return(double(path: "#{pwd}.git/"))
       end
 
       it 'returns the repo workdir' do


### PR DESCRIPTION
Rugged 0.21.0 uses a different api for the discovery and returns an object instead of a string, so `gsub` was not available.
