### PR TITLE
Load active_support before any other active_support file.

### DIFF
--- a/lib/anvil.rb
+++ b/lib/anvil.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'anvil/version'
+require 'active_support'
 require 'active_support/core_ext'
 
 # Main anvil module


### PR DESCRIPTION
This loads activesupport/dependencies/autoload.rb.
