### PR TITLE
Make bump work on project's current branch

### DIFF
--- a/lib/tasks/gem/bump_task.rb
+++ b/lib/tasks/gem/bump_task.rb
@@ -58,7 +58,7 @@ class Gem::BumpTask < Anvil::Task
     git.add 'VERSION'
     git.commit "Bump version v#{version}"
     git.add_tag "v#{version}"
-    git.push
+    git.push('origin', git.current_branch)
   end
 
   def write_version(version)
@@ -72,7 +72,7 @@ class Gem::BumpTask < Anvil::Task
 
   def prepare_repo
     if clean? || force?
-      git.pull
+      git.pull('origin', git.current_branch)
     else
       fail Anvil::RepoNotClean
     end


### PR DESCRIPTION
Seems that currently this task just take care of master branch using pull and push by default:

http://www.rubydoc.info/github/schacon/ruby-git/Git/Base#pull-instance_method
http://www.rubydoc.info/github/schacon/ruby-git/Git/Base#push-instance_method

If the project is not on master, the bump task pulls master on it and then pushes it to master. As it's not doing checkout of master, it could generate inconsistency issues when we work with different branches.

This PR modifies pull/push calls to work with current  branch of the project where we are working on (#19).
